### PR TITLE
Fixed version setting for scripts with same name

### DIFF
--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -250,9 +250,9 @@ export class Migration {
     fileArr.forEach((file) => {
       let script;
       try {
-        script = module.parent.parent.require(
+        script = {...module.parent.parent.require(
           path.resolve(process.cwd(), dirPath, file)
-        );
+        )};
       } catch (e) {
         this.writeLog(`Unable to load script from ${file}! (${e})`);
         // typescript/javascript file are expected to load successfully from folder


### PR DESCRIPTION
Fixed issue when we have script with name X loaded, & another script with same name not loaded. 
Before both scripts got the version of the not loaded one, now loaded script's version does not change if a script with the same name appears.